### PR TITLE
Add request id inside comment when exporting Har

### DIFF
--- a/packages/insomnia-app/app/common/har.js
+++ b/packages/insomnia-app/app/common/har.js
@@ -213,7 +213,7 @@ export async function exportHar(exportRequests: Array<ExportRequest>): Promise<H
         receive: 0,
         ssl: -1,
       },
-      comment: request.name,
+      comment: `${request.name} - ${request._id}`,
     };
 
     entries.push(entry);


### PR DESCRIPTION
In order to identify requests that are similar when exporting har, the request id can be added within the comment of the same.

Before the comment of the entry was the `request.name`, now it would have the form `request.name - request.id`

This is my first pull request, if there is anything I need to change or do please guide me.